### PR TITLE
Fix: Add script includes and correct preset handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,6 +188,12 @@
     </div>
 
     <!-- Scripts omitted for brevity but same as before -->
+    <script src="js/config.js"></script>
+    <script src="js/shape-library.js"></script>
+    <script src="js/phase-definitions.js"></script>
+    <script src="js/particles.js"></script>
+    <script src="js/animation-system.js"></script>
+    <script src="js/ui-controls.js"></script>
     
     <!-- Additional Modal Styles -->
     <style>

--- a/js/config.js
+++ b/js/config.js
@@ -85,16 +85,16 @@ document.addEventListener('DOMContentLoaded', function() {
             const preset = presets[this.value];
             if (preset) {
                 // Update form controls
-                document.getElementById('nodeCount').value = preset.nodeCount;
-                document.getElementById('nodeCountValue').textContent = preset.nodeCount;
+                // document.getElementById('nodeCount').value = preset.nodeCount; // Element does not exist
+                // document.getElementById('nodeCountValue').textContent = preset.nodeCount; // Element does not exist
                 document.getElementById('connectionDistance').value = preset.connectionDistance;
                 document.getElementById('connectionValue').textContent = preset.connectionDistance;
                 document.getElementById('animationSpeed').value = preset.animationSpeed;
                 document.getElementById('speedValue').textContent = preset.animationSpeed;
                 document.getElementById('particleSize').value = preset.particleSize;
                 document.getElementById('sizeValue').textContent = preset.particleSize;
-                document.getElementById('mixIntensity').value = preset.mixIntensity;
-                document.getElementById('mixValue').textContent = preset.mixIntensity;
+                // document.getElementById('mixIntensity').value = preset.mixIntensity; // Element does not exist
+                // document.getElementById('mixValue').textContent = preset.mixIntensity; // Element does not exist
                 document.getElementById('seedInput').value = preset.seed;
                 document.getElementById('backgroundColor').value = preset.backgroundColor;
                 document.getElementById('showTrails').checked = preset.effects.trails;


### PR DESCRIPTION
- Added missing JavaScript file includes to index.html to enable application functionality.
- Commented out references to non-existent 'nodeCount' and 'mixIntensity' elements in the preset handler (js/config.js) to prevent runtime errors when applying presets.